### PR TITLE
feat: Auth 관련 api 개발[한재서]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping("/signup")
+    @PostMapping("/signup")
     public ResponseEntity<Void> signup(
             @RequestPart("data") SignupDto signupDto,
             @RequestPart(value = "image", required = false) MultipartFile file) {

--- a/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
@@ -1,9 +1,11 @@
 package boot.kakaotech.communitybe.auth.controller;
 
 import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.dto.ValueDto;
 import boot.kakaotech.communitybe.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,7 +25,23 @@ public class AuthController {
         log.info("[AuthController] 회원가입 요청 시작");
 
         authService.signup(signupDto, file);
+        log.info("[AuthController] 회원가입 성공");
+
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/duplications/email")
+    public ResponseEntity<Void> duplicateEmail(
+            @RequestBody ValueDto email
+            ) {
+        log.info("[AuthController] 이메일 중복확인 시작");
+
+        boolean isExist = authService.checkEmail(email);
+        log.info("[AuthController] 이메일 중복확인 성공");
+
+        return isExist ?
+                ResponseEntity.status(HttpStatus.CONFLICT).build() :
+                ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
@@ -44,4 +44,18 @@ public class AuthController {
                 ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/duplications/nickname")
+    public ResponseEntity<Void> duplicateNickname(
+            @RequestBody ValueDto nickname
+    ) {
+        log.info("[AuthController] 닉네임 중복확인 시작");
+
+        boolean isExist = authService.checkNickname(nickname);
+        log.info("[AuthController] 닉네임 중복확인 성공");
+
+        return isExist ?
+                ResponseEntity.status(HttpStatus.CONFLICT).build() :
+                ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package boot.kakaotech.communitybe.auth.controller;
+
+import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/signup")
+    public ResponseEntity<Void> signup(
+            @RequestPart("data") SignupDto signupDto,
+            @RequestPart(value = "image", required = false) MultipartFile file) {
+        log.info("[AuthController] 회원가입 요청 시작");
+
+        authService.signup(signupDto, file);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/dto/CustomUserDetails.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/dto/CustomUserDetails.java
@@ -29,4 +29,8 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return user.getEmail();
     }
+
+    public User getUser() {
+        return user;
+    }
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/dto/CustomUserDetails.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/dto/CustomUserDetails.java
@@ -1,0 +1,32 @@
+package boot.kakaotech.communitybe.auth.dto;
+
+import boot.kakaotech.communitybe.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    // 권한 관련 설계가 아직 없어 일단 빈 리스트 반환
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/dto/LoginUserDto.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/dto/LoginUserDto.java
@@ -1,0 +1,16 @@
+package boot.kakaotech.communitybe.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginUserDto {
+
+    private String profileImageUrl;
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/dto/SignupDto.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/dto/SignupDto.java
@@ -1,0 +1,20 @@
+package boot.kakaotech.communitybe.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupDto {
+
+    private String email;
+
+    private String password;
+
+    private String nickname;
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/dto/ValueDto.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/dto/ValueDto.java
@@ -1,0 +1,16 @@
+package boot.kakaotech.communitybe.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValueDto {
+
+    private String value;
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
@@ -1,35 +1,67 @@
 package boot.kakaotech.communitybe.auth.filter;
 
+import boot.kakaotech.communitybe.auth.service.CustomUserDetailsService;
+import boot.kakaotech.communitybe.auth.service.JwtService;
+import boot.kakaotech.communitybe.util.CookieUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.PathContainer;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class JwtVerificationFilter extends OncePerRequestFilter {
 
-    private static final String ACCESS_TOKEN = "access_token";
-    private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final JwtService jwtService;
+    private final CustomUserDetailsService userDetailsService;
+
+    private final PathPatternParser patternParser = new PathPatternParser();
+    private final CookieUtil cookieUtil;
+
+    private final List<PathPattern> excludedUrls = Arrays.asList(
+            "/api/auth/**"
+    ).stream().map(patternParser::parse).toList();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("[JwtVerificationFilter] 토큰 검증 시작");
 
-        String authHeader = request.getHeader(ACCESS_TOKEN);
+        String authHeader = request.getHeader(AUTHORIZATION);
         String accessToken = null;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             accessToken = authHeader.substring(7);
         }
 
-        // TODO: 토큰 검증 로직
+        if (accessToken != null) {
+            try {
+                processAccessToken(accessToken, response);
+            } catch (ExpiredJwtException e) {
+                log.info("[JwtVerificationFilter] Access token 만료");
+
+                // TODO: refresh token으로 갱신하는 로직 추가
+                // 일단은 401로 처리
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
 
         log.info("[JwtVerificationFilter] 토큰 검증 성공");
         filterChain.doFilter(request, response);
@@ -38,9 +70,26 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
+        PathContainer container = PathContainer.parsePath(path);
 
-        // TODO: boolean shouldNotFilter 확인
-        return false;
+        return excludedUrls.stream().anyMatch(p -> p.matches(container));
+    }
+
+    private void processAccessToken(String accessToken, HttpServletResponse response) {
+        String email = jwtService.getEmailFromToken(accessToken);
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails =  userDetailsService.loadUserByUsername(email);
+
+            if (jwtService.isValidAccessToken(accessToken, userDetails)) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
     }
 
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
@@ -75,6 +75,12 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         return excludedUrls.stream().anyMatch(p -> p.matches(container));
     }
 
+    /**
+     * SecurityContextHolder에 저장된 인증 정보가 없다면 새로 저장하는 메서드
+     *
+     * @param accessToken
+     * @param response
+     */
     private void processAccessToken(String accessToken, HttpServletResponse response) {
         String email = jwtService.getEmailFromToken(accessToken);
 

--- a/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/filter/JwtVerificationFilter.java
@@ -1,0 +1,46 @@
+package boot.kakaotech.communitybe.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtVerificationFilter extends OncePerRequestFilter {
+
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String REFRESH_TOKEN = "refresh_token";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("[JwtVerificationFilter] 토큰 검증 시작");
+
+        String authHeader = request.getHeader(ACCESS_TOKEN);
+        String accessToken = null;
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            accessToken = authHeader.substring(7);
+        }
+
+        // TODO: 토큰 검증 로직
+
+        log.info("[JwtVerificationFilter] 토큰 검증 성공");
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        // TODO: boolean shouldNotFilter 확인
+        return false;
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/handler/CustomLogoutHandler.java
@@ -1,0 +1,47 @@
+package boot.kakaotech.communitybe.auth.handler;
+
+import boot.kakaotech.communitybe.auth.service.JwtService;
+import boot.kakaotech.communitybe.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final JwtService jwtService;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        log.info("[LogoutHandler] 로그아웃 처리 시작");
+        try {
+            // access token은 프론트에서 삭제하고 refresh token만 보내기
+            Cookie refreshCookie = cookieUtil.getCookie(request, "refresh_token");
+            String refreshToken = null;
+            if (refreshCookie != null) {
+                refreshToken = refreshCookie.getValue();
+                cookieUtil.deleteCookie(response, "refresh_token");
+
+                // TODO: redis에 저장된 refreshToken 지우는 로직 구현
+
+                response.setStatus(HttpServletResponse.SC_OK);
+            }
+        } catch (Exception e) {
+            log.error("[LogoutHandler] 에러가 발생하였습니다.", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/handler/LoginFailureHandler.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/handler/LoginFailureHandler.java
@@ -1,0 +1,29 @@
+package boot.kakaotech.communitybe.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.info("[LoginFailureHandler] 로그인 실패");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+
+        String body = """
+                {"message": "Invalid_email_or_password"}
+                """;
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/handler/LoginSuccessHandler.java
@@ -1,0 +1,53 @@
+package boot.kakaotech.communitybe.auth.handler;
+
+import boot.kakaotech.communitybe.auth.dto.CustomUserDetails;
+import boot.kakaotech.communitybe.auth.dto.LoginUserDto;
+import boot.kakaotech.communitybe.auth.service.JwtService;
+import boot.kakaotech.communitybe.user.entity.User;
+import boot.kakaotech.communitybe.util.CookieUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final CookieUtil cookieUtil;
+    private final ObjectMapper objectMapper;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        log.info("[LoginSuccessHandler] 로그인 성공");
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        User user = userDetails.getUser();
+
+        String accessToken = jwtService.generateAccessToken(user);
+        String refreshToken = jwtService.generateRefreshToken(user);
+
+        cookieUtil.addCookie(response, "refresh_token", refreshToken, (int) jwtService.getRefreshTokenExpireTime() / 1000);
+
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(
+                LoginUserDto.builder()
+                        .profileImageUrl(user.getProfileImageUrl())
+                        .build())
+        );
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
@@ -1,10 +1,13 @@
 package boot.kakaotech.communitybe.auth.service;
 
 import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.dto.ValueDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AuthService {
 
     void signup(SignupDto signupDto, MultipartFile file);
+
+    boolean checkEmail(ValueDto valueDto);
 
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package boot.kakaotech.communitybe.auth.service;
+
+import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AuthService {
+
+    void signup(SignupDto signupDto, MultipartFile file);
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthService.java
@@ -10,4 +10,6 @@ public interface AuthService {
 
     boolean checkEmail(ValueDto valueDto);
 
+    boolean checkNickname(ValueDto valueDto);
+
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
@@ -1,0 +1,71 @@
+package boot.kakaotech.communitybe.auth.service;
+
+import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.common.s3.service.S3Service;
+import boot.kakaotech.communitybe.user.entity.User;
+import boot.kakaotech.communitybe.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void signup(SignupDto signupDto, MultipartFile file) {
+        log.info("[AuthService] 회원가입 시작");
+
+        validateSignup(signupDto);
+        User user = User.builder()
+                .email(signupDto.getEmail())
+                .password(passwordEncoder.encode(signupDto.getPassword()))
+                .nickname(signupDto.getNickname())
+                .build();
+
+        userRepository.save(user);
+        // TODO: s3Service의 uploadUserProfile을 비동기처리 후 update 쿼리
+        String profileImageUrl = s3Service.uploadUserProfile(user, file);
+        log.info("[AuthService] 회원가입 성공");
+    }
+
+    /**
+     * signup 요청 시 받은 데이터 검증 메서드
+     * 1. 이메일 형식 체크
+     * 2. 비밀번호 길이, 영문 대문자, 소문자, 특수문자, 숫자 체크
+     * 3. 닉네임 길이, 공백 체크
+     *
+     * @param signupDto
+     */
+    private void validateSignup(SignupDto signupDto) {
+        String emailRegex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+        String passwordRegex = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=`~\\[\\]{};':\",./<>?]).+$";
+        String nicknameRegex = ".*\\s.*";
+
+        String email = signupDto.getEmail();
+        if (email.matches(emailRegex)) {
+            // TODO: 커스텀 에러 던지기
+        }
+
+        String password = signupDto.getPassword();
+        if (password.length() < 8 || password.length() > 20 || password.matches(passwordRegex)) {
+            // TODO: 커스텀 에러 던지기
+        }
+
+        String nickname = signupDto.getNickname();
+        if (nickname.isEmpty() || nickname.length() > 10 || nickname.matches(nicknameRegex)) {
+            // TODO: 커스텀 에러 던지기
+        }
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
@@ -51,6 +51,17 @@ public class AuthServiceImpl implements AuthService {
         return user != null;
     }
 
+    @Override
+    public boolean checkNickname(ValueDto value) {
+        log.info("[AuthService] 닉네임 중복확인 시작");
+
+        String nickname = value.getValue();
+        validateNickname(nickname);
+        User user = userRepository.findByNickname(nickname).orElse(null);
+
+        return user != null;
+    }
+
     /**
      * signup 요청 시 받은 데이터 검증 메서드
      * 1. 이메일 형식 체크

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package boot.kakaotech.communitybe.auth.service;
 
 import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.dto.ValueDto;
 import boot.kakaotech.communitybe.common.s3.service.S3Service;
 import boot.kakaotech.communitybe.user.entity.User;
 import boot.kakaotech.communitybe.user.repository.UserRepository;
@@ -39,6 +40,17 @@ public class AuthServiceImpl implements AuthService {
         log.info("[AuthService] 회원가입 성공");
     }
 
+    @Override
+    public boolean checkEmail(ValueDto value) {
+        log.info("[AuthService] 이메일 중복확인 시작");
+
+        String email = value.getValue();
+        validateEmail(email);
+        User user = userRepository.findByEmail(email).orElse(null);
+
+        return user != null;
+    }
+
     /**
      * signup 요청 시 받은 데이터 검증 메서드
      * 1. 이메일 형식 체크
@@ -48,22 +60,36 @@ public class AuthServiceImpl implements AuthService {
      * @param signupDto
      */
     private void validateSignup(SignupDto signupDto) {
-        String emailRegex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
-        String passwordRegex = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=`~\\[\\]{};':\",./<>?]).+$";
-        String nicknameRegex = ".*\\s.*";
-
         String email = signupDto.getEmail();
-        if (email.matches(emailRegex)) {
-            // TODO: 커스텀 에러 던지기
-        }
+        validateEmail(email);
 
         String password = signupDto.getPassword();
-        if (password.length() < 8 || password.length() > 20 || password.matches(passwordRegex)) {
-            // TODO: 커스텀 에러 던지기
-        }
+        validatePassword(password);
 
         String nickname = signupDto.getNickname();
-        if (nickname.isEmpty() || nickname.length() > 10 || nickname.matches(nicknameRegex)) {
+        validateNickname(nickname);
+    }
+
+    private void validateEmail(String email) {
+        String regex = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+
+        if (!email.matches(regex)) {
+            // TODO: 커스텀 에러 던지기
+        }
+    }
+
+    private void validatePassword(String password) {
+        String regex = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=`~\\[\\]{};':\",./<>?]).+$";
+
+        if (password.length() < 8 || password.length() > 20 || password.matches(regex)) {
+            // TODO: 커스텀 에러 던지기
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        String regex = ".*\\s.*";
+
+        if (nickname.isEmpty() || nickname.length() > 10 || nickname.matches(regex)) {
             // TODO: 커스텀 에러 던지기
         }
     }

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package boot.kakaotech.communitybe.auth.service;
+
+import boot.kakaotech.communitybe.auth.dto.CustomUserDetails;
+import boot.kakaotech.communitybe.user.entity.User;
+import boot.kakaotech.communitybe.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username);
+
+        if (user == null) {
+            throw new UsernameNotFoundException(username);
+        }
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/CustomUserDetailsService.java
@@ -17,7 +17,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(username);
+        User user = userRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException("가입된 유저가 없습니다."));
 
         if (user == null) {
             throw new UsernameNotFoundException(username);

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
@@ -1,0 +1,16 @@
+package boot.kakaotech.communitybe.auth.service;
+
+import boot.kakaotech.communitybe.user.entity.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface JwtService {
+
+    boolean isValidAccessToken(String accessToken, UserDetails user);
+
+    boolean isValidRefreshToken(String refreshToken, UserDetails user);
+
+    String generateAccessToken(User user);
+
+    String generateRefreshToken(User user);
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
@@ -15,4 +15,6 @@ public interface JwtService {
 
     String getEmailFromToken(String token);
 
+    long getRefreshTokenExpireTime();
+
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtService.java
@@ -13,4 +13,6 @@ public interface JwtService {
 
     String generateRefreshToken(User user);
 
+    String getEmailFromToken(String token);
+
 }

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
@@ -1,0 +1,176 @@
+package boot.kakaotech.communitybe.auth.service;
+
+import boot.kakaotech.communitybe.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class JwtServiceImpl implements JwtService {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.expireTime.accessToken}")
+    private long accessTokenExpireTime;
+
+    @Value("${jwt.expireTime.refreshToken}")
+    private long refreshTokenExpireTime;
+
+    /**
+     * access token 유효성 검사
+     * - 토큰에서 signature 비교 후 subject로 설정해놓은 email 비교하여 유효성 검사
+     * - 토큰 만료시간 검사
+     *
+     * @param accessToken
+     * @param user
+     * @return
+     */
+    @Override
+    public boolean isValidAccessToken(String accessToken, UserDetails user) {
+        String email = extractEmailFromToken(accessToken);
+
+        if (!email.equals(user.getUsername())) {
+            // TODO: 커스텀 예외 던지기
+        }
+
+        if (!isExpiredToken(accessToken)) {
+            // TODO: 커스텀 예외 던지기
+        }
+
+        return true;
+    }
+
+    /**
+     * refresh token 유효성 검사
+     * - 토큰에서 signature 비교 후 subject로 설정해놓은 email 비교
+     * - 토큰 만료시간 검사
+     * - 레디스에 해당 유저의 리프레시토큰이 저장되어 있는지,
+     *   저장되어 있다면 저장된 리프레시토큰과 일치하는지 검사
+     *
+     * @param refreshToken
+     * @param user
+     * @return
+     */
+    @Override
+    public boolean isValidRefreshToken(String refreshToken, UserDetails user) {
+        String email = extractEmailFromToken(refreshToken);
+        if (!email.equals(user.getUsername())) {
+            // TODO: 커스텀 예외 던지기
+        }
+
+        if (!isExpiredToken(refreshToken)) {
+            // TODO: 커스텀 예외 던지기
+        }
+
+        // TODO: redis에 저장된 리프레시 토큰과 비교 로직 추가
+
+        return true;
+    }
+
+    /**
+     * User 객체를 받아 액세스토큰을 생성하는 메서드
+     * 로그인 성공 시 HTTPONLY COOKIES에 담아 반환 예정
+     *
+     * @param user
+     * @return
+     */
+    @Override
+    public String generateAccessToken(User user) {
+        return generateToken(user, accessTokenExpireTime);
+    }
+
+    /**
+     * User 객체를 받아 리프레시토큰을 생성하는 메서드
+     * 로그인 성공 시 redis에 저장 후 헤더에 담아 반환 예정
+     *
+     * @param user
+     * @return
+     */
+    @Override
+    public String generateRefreshToken(User user) {
+        return generateToken(user, refreshTokenExpireTime);
+    }
+
+    /**
+     * 토큰에 subject로 담긴 이메일을 추출하는 메서드
+     *
+     * @param token
+     * @return
+     */
+    private String extractEmailFromToken(String token) {
+        Claims claims = extractAllClaimsFromToken(token);
+
+        return claims.getSubject();
+    }
+
+    /**
+     * 토큰 만료 여부를 확인하는 메서드
+     *
+     * @param token
+     * @return
+     */
+    private boolean isExpiredToken(String token) {
+        Claims claims = extractAllClaimsFromToken(token);
+
+        Date expiration = claims.getExpiration();
+        return expiration.before(new Date());
+    }
+
+    /**
+     * 토큰을 받아 signature 비교 후 모든 클레임을 추출하여 반환하는 메서드
+     *
+     * @param token
+     * @return
+     */
+    private Claims extractAllClaimsFromToken(String token) {
+        return Jwts
+                .parser()
+                .verifyWith(getSigninKey())
+                .build()
+                .parseClaimsJws(token)
+                .getPayload();
+    }
+
+    /**
+     * User와 만료시간을 받아 토큰을 생성하는 메서드
+     * 토큰에는 subject로 unique한 유저의 email과 클레임으로 userId가 들어간다.
+     * 클레임에 있는 userId는 추후에 토큰에서 추출하여 api에서 사용할 예정
+     *
+     * @param user
+     * @param expireTime
+     * @return
+     */
+    private String generateToken(User user, long expireTime) {
+        return Jwts
+                .builder()
+                .subject(user.getEmail())
+                .claim("userId", user.getId())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expireTime))
+                .signWith(getSigninKey())
+                .compact();
+    }
+
+    /**
+     * secretKey를 decode해서 반환하는 메서드
+     *
+     * @return
+     */
+    private SecretKey getSigninKey() {
+        byte[] keyBytes = Decoders.BASE64URL.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
@@ -100,6 +100,11 @@ public class JwtServiceImpl implements JwtService {
         return extractEmailFromToken(token);
     }
 
+    @Override
+    public long getRefreshTokenExpireTime() {
+        return refreshTokenExpireTime;
+    }
+
     /**
      * 토큰에 subject로 담긴 이메일을 추출하는 메서드
      *

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
@@ -45,10 +45,6 @@ public class JwtServiceImpl implements JwtService {
             // TODO: 커스텀 예외 던지기
         }
 
-        if (!isExpiredToken(accessToken)) {
-            // TODO: 커스텀 예외 던지기
-        }
-
         return true;
     }
 
@@ -67,10 +63,6 @@ public class JwtServiceImpl implements JwtService {
     public boolean isValidRefreshToken(String refreshToken, UserDetails user) {
         String email = extractEmailFromToken(refreshToken);
         if (!email.equals(user.getUsername())) {
-            // TODO: 커스텀 예외 던지기
-        }
-
-        if (!isExpiredToken(refreshToken)) {
             // TODO: 커스텀 예외 던지기
         }
 
@@ -101,6 +93,11 @@ public class JwtServiceImpl implements JwtService {
     @Override
     public String generateRefreshToken(User user) {
         return generateToken(user, refreshTokenExpireTime);
+    }
+
+    @Override
+    public String getEmailFromToken(String token) {
+        return extractEmailFromToken(token);
     }
 
     /**

--- a/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/auth/service/JwtServiceImpl.java
@@ -22,10 +22,10 @@ public class JwtServiceImpl implements JwtService {
     @Value("${jwt.secret}")
     private String secretKey;
 
-    @Value("${jwt.expireTime.accessToken}")
+    @Value("${jwt.expire_time.access_token}")
     private long accessTokenExpireTime;
 
-    @Value("${jwt.expireTime.refreshToken}")
+    @Value("${jwt.expire_time.refresh_token}")
     private long refreshTokenExpireTime;
 
     /**

--- a/src/main/java/boot/kakaotech/communitybe/common/s3/service/S3Service.java
+++ b/src/main/java/boot/kakaotech/communitybe/common/s3/service/S3Service.java
@@ -1,0 +1,10 @@
+package boot.kakaotech.communitybe.common.s3.service;
+
+import boot.kakaotech.communitybe.user.entity.User;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+
+    String uploadUserProfile(User user, MultipartFile file);
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/common/s3/service/S3ServiceImpl.java
+++ b/src/main/java/boot/kakaotech/communitybe/common/s3/service/S3ServiceImpl.java
@@ -1,0 +1,20 @@
+package boot.kakaotech.communitybe.common.s3.service;
+
+import boot.kakaotech.communitybe.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3ServiceImpl implements S3Service {
+
+
+    @Override
+    public String uploadUserProfile(User user, MultipartFile file) {
+        // TODO: S3에 이미지 업로드 후 저장된 url 반환 로직 구현
+        return "";
+    }
+}

--- a/src/main/java/boot/kakaotech/communitybe/config/EncoderConfig.java
+++ b/src/main/java/boot/kakaotech/communitybe/config/EncoderConfig.java
@@ -1,0 +1,15 @@
+package boot.kakaotech.communitybe.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class EncoderConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
+++ b/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
@@ -1,15 +1,22 @@
 package boot.kakaotech.communitybe.config;
 
 import boot.kakaotech.communitybe.auth.filter.JwtVerificationFilter;
+import boot.kakaotech.communitybe.auth.handler.CustomLogoutHandler;
+import boot.kakaotech.communitybe.auth.handler.LoginFailureHandler;
+import boot.kakaotech.communitybe.auth.handler.LoginSuccessHandler;
+import boot.kakaotech.communitybe.auth.service.CustomUserDetailsService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -23,6 +30,12 @@ import java.util.Arrays;
 @Slf4j
 public class SecurityConfig {
 
+    private final LoginSuccessHandler loginSuccessHandler;
+    private final LoginFailureHandler loginFailureHandler;
+    private final CustomLogoutHandler logoutHandler;
+    private final PasswordEncoder passwordEncoder;
+    private final CustomUserDetailsService userDetailsService;
+
     @Value("${frontend.url}")
     private String frontendUrl;
 
@@ -34,6 +47,14 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider(CustomUserDetailsService customUserDetailsService, PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(customUserDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
     }
 
     @Bean
@@ -50,17 +71,18 @@ public class SecurityConfig {
                     log.info("[SecurityConfig] URL 인가 구성 완료");
                 })
                 .addFilterBefore(jwtVerificationFilter, UsernamePasswordAuthenticationFilter.class)
+                .authenticationProvider(authenticationProvider(userDetailsService, passwordEncoder))
                 .formLogin(form -> {
                     form
                             .loginProcessingUrl("/api/auth/signin")
-                    // TODO
-//                            .successHandler()
-//                            .failureHandler();
+                            .successHandler(loginSuccessHandler)
+                            .failureHandler(loginFailureHandler);
                     ;
                 })
                 .logout(logout -> {
                     logout
                             .logoutUrl("/api/auth/logout")
+                            .addLogoutHandler(logoutHandler)
                             .addLogoutHandler((request, response, authentication) -> {
                                 response.setStatus(HttpServletResponse.SC_OK);
                             })

--- a/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
+++ b/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package boot.kakaotech.communitybe.config;
 
+import boot.kakaotech.communitybe.auth.filter.JwtVerificationFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
@@ -35,7 +37,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtVerificationFilter jwtVerificationFilter) throws Exception {
         log.info("[SecurityConfig] 보안 필터 구성 시작");
         http
                 .csrf(csrf -> csrf.disable())
@@ -47,6 +49,7 @@ public class SecurityConfig {
                                     .anyRequest().authenticated();
                     log.info("[SecurityConfig] URL 인가 구성 완료");
                 })
+                .addFilterBefore(jwtVerificationFilter, UsernamePasswordAuthenticationFilter.class)
                 .formLogin(form -> {
                     form
                             .loginProcessingUrl("/api/auth/signin")

--- a/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
+++ b/src/main/java/boot/kakaotech/communitybe/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package boot.kakaotech.communitybe.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityConfig {
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Bean
+    UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList(frontendUrl));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        log.info("[SecurityConfig] 보안 필터 구성 시작");
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(requests -> {
+                    requests
+                                    .requestMatchers(
+                                            "/"
+                                    ).permitAll()
+                                    .anyRequest().authenticated();
+                    log.info("[SecurityConfig] URL 인가 구성 완료");
+                })
+                .formLogin(form -> {
+                    form
+                            .loginProcessingUrl("/api/auth/signin")
+                    // TODO
+//                            .successHandler()
+//                            .failureHandler();
+                    ;
+                })
+                .logout(logout -> {
+                    logout
+                            .logoutUrl("/api/auth/logout")
+                            .addLogoutHandler((request, response, authentication) -> {
+                                response.setStatus(HttpServletResponse.SC_OK);
+                            })
+                            .permitAll();
+                })
+                .sessionManagement(session -> {
+                    log.info("[SecurityConfig] 세션 관리 정책: STATELESS");
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                });
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/boot/kakaotech/communitybe/post/entity/Post.java
+++ b/src/main/java/boot/kakaotech/communitybe/post/entity/Post.java
@@ -40,13 +40,13 @@ public class Post {
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime deletedAt;
 
-    @OneToMany(mappedBy = "post_like")
+    @OneToMany(mappedBy = "post")
     private List<PostLike> likes;
 
-    @OneToMany(mappedBy = "post_image")
+    @OneToMany(mappedBy = "post")
     private List<PostImage> images;
 
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "post")
     private List<Comment> comments;
 
 }

--- a/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
+++ b/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
+++ b/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
@@ -3,8 +3,10 @@ package boot.kakaotech.communitybe.user.repository;
 import boot.kakaotech.communitybe.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Integer> {
 
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
+++ b/src/main/java/boot/kakaotech/communitybe/user/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package boot.kakaotech.communitybe.user.repository;
 
-public interface UserRepository {
+import boot.kakaotech.communitybe.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+
+    User findByEmail(String email);
+
 }

--- a/src/main/java/boot/kakaotech/communitybe/util/CookieUtil.java
+++ b/src/main/java/boot/kakaotech/communitybe/util/CookieUtil.java
@@ -1,0 +1,4 @@
+package boot.kakaotech.communitybe.util;
+
+public class CookieUtil {
+}

--- a/src/main/java/boot/kakaotech/communitybe/util/CookieUtil.java
+++ b/src/main/java/boot/kakaotech/communitybe/util/CookieUtil.java
@@ -1,4 +1,86 @@
 package boot.kakaotech.communitybe.util;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
 public class CookieUtil {
+
+    /**
+     * HttpOnly 쿠키를 생성하는 메서드
+     * 1. 백엔드 api 공통 uri인 "/api"를 path로 설정
+     * 2. 커뮤니티이므로 링크를 통해 들어올 수 있게 same site Lax로 설정
+     * 3. Javascript 접근을 막는게 보안 상 좋을 것이라 판단해서 httponly true
+     * 4. 일단 배포하기 전에는 https를 사용하지 않을거라 secure false
+     * 5. 만료시간 설정
+     *
+     * @param response
+     * @param name
+     * @param value
+     * @param maxAge
+     */
+    public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        log.info("[CookieUtil] 쿠키 생성 시작 - 이름: {}, 만료시간: {}", name, maxAge);
+
+        ResponseCookie cookie = ResponseCookie.from(name, value).maxAge(maxAge)
+                .path("/api")
+                .sameSite("Lax")
+                .httpOnly(true)
+                .secure(false)
+                .maxAge(maxAge)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        log.info("[CookieUtil] 쿠키 생성 성공");
+    }
+
+    /**
+     * request에서 원하는 쿠키를 반환하는 메서드
+     * 전체 쿠키 조회 후 헤더에 저장된 이름으로 조회 후 반환
+     *
+     * @param request
+     * @param name
+     * @return
+     */
+    public Cookie getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return cookie;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * response에 쿠키를 ""와 유지시간을 0으로 세팅 후 반환하는 메서드
+     *
+     * @param response
+     * @param name
+     */
+    public void deleteCookie(HttpServletResponse response, String name) {
+        log.info("[CookieUtil] 쿠키 삭제 시작 - 이름: {}", name);
+
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .path("/api")
+                .sameSite("Lax")
+                .httpOnly(true)
+                .secure(false)
+                .maxAge(0)
+                .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        log.info("[CookieUtil] 쿠키 삭제 성공 - 이름: {}", name);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,12 @@ spring:
 logging:
   level:
     org.hibernate.sql: debug
+
+jwt:
+  secret: ${JWT_SECRET}
+  expire_time:
+    access_token: ${ACCESS_TOKEN_EXPIRE_TIME}
+    refresh_token: ${REFRESH_TOKEN_EXPIRE_TIME}
+
+frontend:
+  url: ${FRONTEND_URL}

--- a/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
+++ b/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
@@ -1,6 +1,7 @@
 package boot.kakaotech.communitybe.auth;
 
 import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.dto.ValueDto;
 import boot.kakaotech.communitybe.auth.service.AuthService;
 import boot.kakaotech.communitybe.user.entity.User;
 import boot.kakaotech.communitybe.user.repository.UserRepository;
@@ -33,6 +34,34 @@ public class AuthTest {
 
         User saved = userRepository.findByEmail(signupDto.getEmail())
                 .orElseThrow(() -> new AssertionError("유저가 저장되지 않았습니다."));
+    }
+
+    @Test
+    @DisplayName("이메일 중복체크: 존재 테스트")
+    public void duplicateExistedEmailTest(){
+        ValueDto valueDto = ValueDto.builder()
+                .value("test@test.com")
+                .build();
+
+        boolean isExist = authService.checkEmail(valueDto);
+
+        if (!isExist) {
+            throw new AssertionError("해당 유저는 존재하지 않습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("이메일 중복체크: 미존재 테스트")
+    public void duplicateNonExistedEmailTest(){
+        ValueDto valueDto = ValueDto.builder()
+                .value("nouser@test.com")
+                .build();
+
+        boolean isExist = authService.checkEmail(valueDto);
+
+        if (isExist) {
+            throw new AssertionError("해당 유저는 존재하지 않습니다.");
+        }
     }
 
 }

--- a/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
+++ b/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
@@ -1,0 +1,38 @@
+package boot.kakaotech.communitybe.auth;
+
+import boot.kakaotech.communitybe.auth.dto.SignupDto;
+import boot.kakaotech.communitybe.auth.service.AuthService;
+import boot.kakaotech.communitybe.user.entity.User;
+import boot.kakaotech.communitybe.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class AuthTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원 가입 테스트")
+    public void signupTest(){
+        SignupDto signupDto = SignupDto.builder()
+                .email("test@test.com")
+                .password("test")
+                .nickname("testUser")
+                .build();
+
+        authService.signup(signupDto, null);
+
+        User saved = userRepository.findByEmail(signupDto.getEmail())
+                .orElseThrow(() -> new AssertionError("유저가 저장되지 않았습니다."));
+    }
+
+}

--- a/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
+++ b/src/test/java/boot/kakaotech/communitybe/auth/AuthTest.java
@@ -46,7 +46,7 @@ public class AuthTest {
         boolean isExist = authService.checkEmail(valueDto);
 
         if (!isExist) {
-            throw new AssertionError("해당 유저는 존재하지 않습니다.");
+            throw new AssertionError("해당 이메일을 사용하는 유저가 존재하지 않습니다.");
         }
     }
 
@@ -60,7 +60,35 @@ public class AuthTest {
         boolean isExist = authService.checkEmail(valueDto);
 
         if (isExist) {
-            throw new AssertionError("해당 유저는 존재하지 않습니다.");
+            throw new AssertionError("해당 이메일을 사용하는 유저가 존재합니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("닉네임 중복체크: 존재 테스트")
+    public void duplicateExistedNicknameTest(){
+        ValueDto valueDto = ValueDto.builder()
+                .value("test")
+                .build();
+
+        boolean isExist = authService.checkNickname(valueDto);
+
+        if (!isExist) {
+            throw new AssertionError("해당 닉네임을 사용하는 유저가 존재하지 않습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("닉네임 중복체크: 미존재 테스트")
+    public void duplicateNonExistedNicknameTest(){
+        ValueDto valueDto = ValueDto.builder()
+                .value("test123123")
+                .build();
+
+        boolean isExist = authService.checkNickname(valueDto);
+
+        if (isExist) {
+            throw new AssertionError("해당 닉네임을 사용하는 유저가 존재합니다.");
         }
     }
 


### PR DESCRIPTION
- summary:
  회원가입, 로그인, 로그아웃, 중복확인 API 개발 완료

- changes:
  1. 회원가입
    1-1. validation 후 새 유저 생성
    1-2. validation 실패 시 커스텀 에러 던지는 부분은 추후 개발 예정
  2. 로그인
    2-1. securityFilterChain에 폼 로그인 관련 설정 추가
    2-2. 로그인성공핸들러 구현
    2-3. 로그인실패핸들러 구현
  3. 로그아웃
    3-1. securityFilterChain에 로그아웃 관련 설정 추가
    3-2. 로그아웃 핸들러 구현
  4. 중복확인
    4-1. 이메일 중복확인 api 구현 
    4-2. 닉네임 중복확인 api 구현
    4-3. validation 실패 시 커스텀 에러는 추후 구현 예정